### PR TITLE
Add multi-region support

### DIFF
--- a/vicohome_bridge/config.yaml
+++ b/vicohome_bridge/config.yaml
@@ -21,6 +21,8 @@ options:
   poll_interval: 60
   log_level: "info"
   base_topic: "vicohome"
+  region: "us"
+  api_base: ""
   bootstrap_history: true
 
 schema:
@@ -29,4 +31,6 @@ schema:
   poll_interval: int?
   log_level: list(debug|info|warning|error)?
   base_topic: str?
+  region: str?
+  api_base: str?
   bootstrap_history: bool?

--- a/vicohome_bridge/run.sh
+++ b/vicohome_bridge/run.sh
@@ -12,6 +12,8 @@ PASSWORD=$(bashio::config 'password')
 POLL_INTERVAL=$(bashio::config 'poll_interval')
 LOG_LEVEL=$(bashio::config 'log_level')
 BASE_TOPIC=$(bashio::config 'base_topic')
+REGION=$(bashio::config 'region')
+API_BASE=$(bashio::config 'api_base')
 BOOTSTRAP_HISTORY=$(bashio::config 'bootstrap_history')
 
 [ -z "${BOOTSTRAP_HISTORY}" ] && BOOTSTRAP_HISTORY="false"
@@ -21,6 +23,12 @@ HAS_BOOTSTRAPPED="false"
 [ -z "${POLL_INTERVAL}" ] && POLL_INTERVAL=60
 [ -z "${LOG_LEVEL}" ] && LOG_LEVEL="info"
 [ -z "${BASE_TOPIC}" ] && BASE_TOPIC="vicohome"
+if [ -z "${REGION}" ] || [ "${REGION}" = "null" ]; then
+  REGION="us"
+fi
+if [ -z "${API_BASE}" ] || [ "${API_BASE}" = "null" ]; then
+  API_BASE=""
+fi
 AVAILABILITY_TOPIC="${BASE_TOPIC}/bridge/status"
 # How often (in seconds) to refresh MQTT discovery payloads so deleted entities get recreated.
 DISCOVERY_REFRESH_SECONDS=300
@@ -29,6 +37,18 @@ bashio::log.info "Vicohome Bridge configuration:"
 bashio::log.info "  poll_interval = ${POLL_INTERVAL}s"
 bashio::log.info "  base_topic    = ${BASE_TOPIC}"
 bashio::log.info "  log_level     = ${LOG_LEVEL}"
+bashio::log.info "  region        = ${REGION}"
+if [ -n "${API_BASE}" ]; then
+  bashio::log.info "  api_base      = ${API_BASE}"
+else
+  bashio::log.info "  api_base      = <auto>"
+fi
+
+API_BASE_LOG="${API_BASE}"
+if [ -z "${API_BASE_LOG}" ]; then
+  API_BASE_LOG="<none>"
+fi
+bashio::log.info "Vicohome region = ${REGION}, api_base override = ${API_BASE_LOG}"
 
 bashio::log.level "${LOG_LEVEL}"
 
@@ -72,6 +92,12 @@ publish_availability online
 export VICOHOME_EMAIL="${EMAIL}"
 export VICOHOME_PASSWORD="${PASSWORD}"
 export VICOHOME_DEBUG="1"
+if [ -n "${REGION}" ]; then
+  export VICOHOME_REGION="${REGION}"
+fi
+if [ -n "${API_BASE}" ]; then
+  export VICOHOME_API_BASE="${API_BASE}"
+fi
 
 mkdir -p /data
 

--- a/vicohome_bridge/vico-cli-main/cmd/devices/get.go
+++ b/vicohome_bridge/vico-cli-main/cmd/devices/get.go
@@ -90,7 +90,8 @@ func getDevice(token string, serialNumber string) (Device, error) {
 		return Device{}, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", "https://api-us.vicohome.io/device/selectsingledevice", bytes.NewBuffer(reqBody))
+	baseURL := auth.GetAPIBaseURL()
+	httpReq, err := http.NewRequest("POST", baseURL+"/device/selectsingledevice", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return Device{}, fmt.Errorf("error creating request: %w", err)
 	}

--- a/vicohome_bridge/vico-cli-main/cmd/devices/list.go
+++ b/vicohome_bridge/vico-cli-main/cmd/devices/list.go
@@ -107,7 +107,8 @@ func listDevices(token string) ([]Device, error) {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", "https://api-us.vicohome.io/device/listuserdevices", bytes.NewBuffer(reqBody))
+	baseURL := auth.GetAPIBaseURL()
+	httpReq, err := http.NewRequest("POST", baseURL+"/device/listuserdevices", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/vicohome_bridge/vico-cli-main/cmd/events/get.go
+++ b/vicohome_bridge/vico-cli-main/cmd/events/get.go
@@ -91,7 +91,8 @@ func getEvent(token string, traceID string) (Event, error) {
 		return Event{}, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequest("POST", "https://api-us.vicohome.io/library/newselectsinglelibrary", bytes.NewBuffer(reqBody))
+	baseURL := auth.GetAPIBaseURL()
+	httpReq, err := http.NewRequest("POST", baseURL+"/library/newselectsinglelibrary", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return Event{}, fmt.Errorf("error creating request: %w", err)
 	}

--- a/vicohome_bridge/vico-cli-main/cmd/events/list.go
+++ b/vicohome_bridge/vico-cli-main/cmd/events/list.go
@@ -141,7 +141,12 @@ func parseTimestamp(timestamp string) (time.Time, error) {
 }
 
 func init() {
-	currentTime := time.Now()
+	// Use UTC when generating the default window so the parsed timestamps
+	// match the actual current time regardless of the host's timezone. When we
+	// previously formatted the defaults in the local timezone (e.g. America/Los_Angeles)
+	// but parsed them as UTC, the effective window ended several hours in the past,
+	// preventing the bridge from ever seeing the most recent events.
+	currentTime := time.Now().UTC()
 	defaultStart := currentTime.Add(-24 * time.Hour).Format("2006-01-02 15:04:05")
 	defaultEnd := currentTime.Format("2006-01-02 15:04:05")
 
@@ -160,7 +165,8 @@ func fetchEvents(token string, request Request) ([]Event, error) {
 		return nil, fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", "https://api-us.vicohome.io/library/newselectlibrary", bytes.NewBuffer(reqBody))
+	baseURL := auth.GetAPIBaseURL()
+	req, err := http.NewRequest("POST", baseURL+"/library/newselectlibrary", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("error creating request: %w", err)
 	}

--- a/vicohome_bridge/vico-cli-main/pkg/auth/auth.go
+++ b/vicohome_bridge/vico-cli-main/pkg/auth/auth.go
@@ -38,6 +38,30 @@ func logDebug(format string, args ...interface{}) {
 	}
 }
 
+// GetAPIBaseURL resolves the Vicohome API base URL based on environment variables.
+// Precedence:
+// 1. VICOHOME_API_BASE: explicit full URL (highest priority)
+// 2. VICOHOME_REGION: shorthand region selector (e.g. "us", "eu")
+// 3. Default fallback to the US API endpoint
+func GetAPIBaseURL() string {
+	if rawBase := strings.TrimSpace(os.Getenv("VICOHOME_API_BASE")); rawBase != "" {
+		return strings.TrimRight(rawBase, "/")
+	}
+
+	region := strings.ToLower(strings.TrimSpace(os.Getenv("VICOHOME_REGION")))
+	switch region {
+	case "eu", "europe":
+		return "https://api-eu.vicoo.tech"
+	case "us", "", "default", "na", "na1":
+		return "https://api-us.vicohome.io"
+	default:
+		if strings.HasPrefix(region, "http://") || strings.HasPrefix(region, "https://") {
+			return strings.TrimRight(region, "/")
+		}
+		return "https://api-us.vicohome.io"
+	}
+}
+
 // LoginRequest represents the JSON request body sent to the Vicohome API
 // during authentication.
 type LoginRequest struct {
@@ -128,7 +152,8 @@ func authenticateDirectly() (string, error) {
 		return "", fmt.Errorf("error marshaling login request: %w", err)
 	}
 
-	req, err := http.NewRequest("POST", "https://api-us.vicohome.io/account/login", bytes.NewBuffer(reqBody))
+	baseURL := GetAPIBaseURL()
+	req, err := http.NewRequest("POST", baseURL+"/account/login", bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("error creating request: %w", err)
 	}


### PR DESCRIPTION
## Summary
- add a helper that derives the Vicohome API base URL from VICOHOME_API_BASE / VICOHOME_REGION so every CLI command can talk to the right region
- expose `region`/`api_base` in the Home Assistant add-on configuration and export them to the vico-cli container environment for backwards-compatible multi-region support

## Testing
- `go build ./...` *(fails: missing github.com/dydx/vico-cli/pkg/output/stdout dependency in go.mod)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691bd0200ca4832ebba7586fd25f7338)